### PR TITLE
refactors! get shortest path with games

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,7 @@ jobs:
         poetry run ruff format --check title_belt_nhl
     - name: Test with pytest
       run: |
-        poetry run pytest
+        poetry run pytest --ruff --ruff-format
     - name: Build package
       run: poetry build
     - name: Store the distribution packages

--- a/README.md
+++ b/README.md
@@ -30,7 +30,14 @@ Options:
   --team TEXT    [required]
   --season TEXT
   --help         Show this message and exit.
+
+Commands:
+  path
+  path-alt
 ```
+
+* use `path-alt` to get a string showing list of games
+* use `path` to get the list of games using a diff algorithm
 
 ## Linting and Formatting
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -220,6 +220,21 @@ tomli = {version = ">=1", markers = "python_version < \"3.11\""}
 dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
+name = "pytest-ruff"
+version = "0.4.1"
+description = "pytest plugin to check ruff requirements."
+optional = false
+python-versions = "<4.0,>=3.8"
+files = [
+    {file = "pytest_ruff-0.4.1-py3-none-any.whl", hash = "sha256:69acd5b2ba68d65998c730b5b4d656788193190e45f61a53aa66ef8b390634a4"},
+    {file = "pytest_ruff-0.4.1.tar.gz", hash = "sha256:2c9a30f15f384c229c881b52ec86cfaf1e79d39530dd7dd5f2d6aebe278f7eb7"},
+]
+
+[package.dependencies]
+pytest = ">=5"
+ruff = ">=0.0.242"
+
+[[package]]
 name = "requests"
 version = "2.32.3"
 description = "Python HTTP for Humans."
@@ -298,4 +313,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "fabc179b080c7b8005ec53016edde1f1f433d3488e2e0cd7dfc08935e3765636"
+content-hash = "73369e4ca87cdfb4ff7ea0318273b9ce578b2836bb0b98410406b74f9a3b928d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ requests = "^2.32.3"
 [tool.poetry.group.dev.dependencies]
 ruff = ">=0.6.0"
 pytest = "^8.3.2"
+pytest-ruff = "^0.4.1"
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "title-belt-nhl"
-version = "0.1.0"
+version = "0.2.0"
 description = ""
 authors = []
 readme = "README.md"

--- a/title_belt_nhl/main.py
+++ b/title_belt_nhl/main.py
@@ -12,11 +12,14 @@ def cli(team, season):
     schedule = Schedule(team, season)
     holder = schedule.belt_holder
 
-    path = schedule.find_nearest_path([holder], holder)
-    games = path.split("vs")
-
     click.echo("=============================================================")
-    click.echo(f"CURRENT SEASON: {schedule.season}")
+    click.echo(f"CURRENT SEASON: {schedule.get_season_pretty()}")
     click.echo(f"CURRENT BELT HOLDER: {holder}")
-    click.echo(f"{len(games)-1} GAMES UNTIL `{team}` HAS A SHOT AT THE BELT")
-    click.echo(path)
+
+    if team == holder:
+        click.echo(f"{team} ALREADY HAS THE BELT!")
+    else:
+        path_matches = schedule.find_nearest_path_games()
+        click.echo(f"{len(path_matches)} GAMES UNTIL `{team}` HAS A SHOT AT THE BELT")
+        for match in path_matches:
+            click.echo(f"\t{match.date_obj} | {match.belt_holder} -> {match}")

--- a/title_belt_nhl/main.py
+++ b/title_belt_nhl/main.py
@@ -19,6 +19,11 @@ def cli(team, season):
     if team == holder:
         click.echo(f"{team} ALREADY HAS THE BELT!")
     else:
+        # path = schedule.find_nearest_path_str([holder], holder)
+        # games = path.split("vs")
+        # click.echo(f"{len(games)-1} GAMES UNTIL `{team}` HAS A SHOT AT THE BELT")
+        # click.echo(path)
+
         path_matches = schedule.find_nearest_path_games()
         click.echo(f"{len(path_matches)} GAMES UNTIL `{team}` HAS A SHOT AT THE BELT")
         for match in path_matches:

--- a/title_belt_nhl/main.py
+++ b/title_belt_nhl/main.py
@@ -2,14 +2,31 @@ import click
 
 from title_belt_nhl.schedule import Schedule
 
+team_option = click.option(
+    "--team", default="VAN", required=True, help="Team abbrev. (ex: CHI)."
+)
+season_option = click.option(
+    "--season", default=None, required=False, help="Example: 20242025."
+)
 
-@click.command()
-@click.option("--team", default="VAN", required=True, help="Team abbrev. (ex: CHI).")
-@click.option("--season", default=None, required=False, help="Example: 20242025.")
-def cli(team, season):
+
+@click.group()
+@team_option
+@season_option
+@click.pass_context
+def cli(ctx, team, season):
     click.echo(f"Calculating shortest path for {team} to challenge for the belt...")
 
     schedule = Schedule(team, season)
+    ctx.ensure_object(dict)
+    ctx.obj["schedule"] = schedule
+
+
+@cli.command()
+@click.pass_context
+def path(ctx):
+    schedule: Schedule = ctx.obj["schedule"]
+    team = schedule.team
     holder = schedule.belt_holder
 
     click.echo("=============================================================")
@@ -19,12 +36,27 @@ def cli(team, season):
     if team == holder:
         click.echo(f"{team} ALREADY HAS THE BELT!")
     else:
-        # path = schedule.find_nearest_path_str([holder], holder)
-        # games = path.split("vs")
-        # click.echo(f"{len(games)-1} GAMES UNTIL `{team}` HAS A SHOT AT THE BELT")
-        # click.echo(path)
-
         path_matches = schedule.find_nearest_path_games()
         click.echo(f"{len(path_matches)} GAMES UNTIL `{team}` HAS A SHOT AT THE BELT")
         for match in path_matches:
             click.echo(f"\t{match.date_obj} | {match.belt_holder} -> {match}")
+
+
+@cli.command()
+@click.pass_context
+def path_alt(ctx):
+    schedule: Schedule = ctx.obj["schedule"]
+    team = schedule.team
+    holder = schedule.belt_holder
+
+    click.echo("=============================================================")
+    click.echo(f"CURRENT SEASON: {schedule.get_season_pretty()}")
+    click.echo(f"CURRENT BELT HOLDER: {holder}")
+
+    if team == holder:
+        click.echo(f"{team} ALREADY HAS THE BELT!")
+    else:
+        path = schedule.find_nearest_path_str([holder], holder)
+        games = path.split("vs")
+        click.echo(f"{len(games)-1} GAMES UNTIL `{team}` HAS A SHOT AT THE BELT")
+        click.echo(path)

--- a/title_belt_nhl/schedule.py
+++ b/title_belt_nhl/schedule.py
@@ -56,7 +56,10 @@ def traverse_matches_backwards(
     while cur_match:
         path_matches.insert(0, cur_match)
 
+        # this line assumes that only away_last *or* home_last is set
+        # and it matches the belt_holder
         last_match = cur_match.away_last or cur_match.home_last
+
         if not last_match:
             break
         cur_match = last_match

--- a/title_belt_nhl/schedule.py
+++ b/title_belt_nhl/schedule.py
@@ -11,33 +11,63 @@ INITIAL_BELT_HOLDER = "FLA"
 SCHEDULE_FILE = Path(__file__).parent / "static" / "schedule_2024_2025.csv"
 
 
-class TitleBelt:
-    team: str
-    belt_holder: str
-
-    def __init__(self, team, belt_holder):
-        self.team = team
-        self.belt_holder = belt_holder
-
-
 class Match:
     home: str
     away: str
-    date: int
+    serial_date: int
+    date_obj: date
+    belt_holder: str = None
+    home_last: str = None
+    away_last: str = None
 
-    def __init__(self, home, away, date):
+    def __init__(self, home, away, serial_date=None, date_obj=None):
         self.home = home
         self.away = away
-        self.date = date
+        self.serial_date = serial_date
+        self.date_obj = date_obj or ExcelDate(serial_date=serial_date).date_obj
 
     def __str__(self):
         return f"[{self.home} vs {self.away}]"
 
 
+def traverse_matches_backwards(
+    matches: list[list[Match]] | None = None, match: Match | None = None
+):
+    """Traverse a tree/graph of matches backwards to find the path to the top.
+
+    Parameters:
+    - matches: list[list[Match]] (optional)
+      - each index of matches represents a depth into the tree/graph of matches
+      - index 0 and last index should each contain a single match
+      - index 0 represents the upcoming match for the current belt holder
+      - last index represents the first match in the graph where the current team
+        can play for the belt
+    - match: Match (optional)
+      - basically same as above, but only pass the last match that we can work up from
+
+    ASSUMPTIONS:
+    - each match specifies either home_last or away_last, matching with the
+      match's belt_holder (home_last if belt_holder is home, or vice versa)
+    """
+    if not matches and not match:
+        raise ValueError("Either matches or match must be provided!")
+    path_matches = []
+    cur_match = match or matches[-1][0]
+    while cur_match:
+        path_matches.insert(0, cur_match)
+
+        last_match = cur_match.away_last or cur_match.home_last
+        if not last_match:
+            break
+        cur_match = last_match
+
+    return path_matches
+
+
 class Schedule:
     team: str
     belt_holder: str
-    games: list[Match] = []
+    matches: list[Match] = []
     from_date: ExcelDate = ExcelDate(date_obj=date.today())
     season: str
 
@@ -61,22 +91,29 @@ class Schedule:
             leagueSchedule, INITIAL_BELT_HOLDER
         )
 
+        self.matches = []
         for game in leagueSchedule:
-            game_date_obj = datetime.strptime(game.gameDate, "%Y-%m-%d")
+            game_date_obj = datetime.strptime(game.gameDate, "%Y-%m-%d").date()
 
             match = Match(
                 game.homeTeam["abbrev"],
                 game.awayTeam["abbrev"],
-                ExcelDate(date_obj=game_date_obj.date()).serial_date,
+                serial_date=ExcelDate(date_obj=game_date_obj).serial_date,
+                date_obj=game_date_obj,
             )
-            self.games.append(match)
+            self.matches.append(match)
 
     def __str__(self):
         return dedent(f""" \
-            Schedule of {len(self.games)} total games
+            Schedule of {len(self.matches)} total matches
             for Team [{self.team}] and Belt Holder [{self.belt_holder}]
             starting from date [{self.from_date.date_obj}] \
             """)
+
+    def get_season_pretty(self):
+        """Convert yyyyYYYY to yyyy-YY (20242025 --> 2024-25)."""
+        if self.season:
+            return f"{self.season[:4]}-{self.season[6:]}"
 
     def set_from_date(self, from_date: Union[date, int]):
         if type(from_date) is date:
@@ -84,40 +121,87 @@ class Schedule:
         if type(from_date) is int:
             self.from_date = ExcelDate(serial_date=from_date)
 
-    def games_after_date_inclusive(
+    def matches_after_date_inclusive(
         self, from_date: Union[date, int] = None
     ) -> list[Match]:
         if from_date:
             self.set_from_date(from_date)
-        return [g for g in self.games if g.date >= self.from_date.serial_date]
+        return [g for g in self.matches if g.serial_date >= self.from_date.serial_date]
 
     def find_match(self, current_belt_holder, from_date) -> Match:
-        for game in self.games_after_date_inclusive(from_date=from_date):
+        for match in self.matches_after_date_inclusive(from_date=from_date):
             if (
-                game.away == current_belt_holder or game.home == current_belt_holder
-            ) and self.from_date.serial_date < game.date:
-                return game
+                match.away == current_belt_holder or match.home == current_belt_holder
+            ) and self.from_date.serial_date < match.serial_date:
+                match.belt_holder = current_belt_holder
+                return match
 
-    def find_nearest_path(self, teams, path_string, from_date=None) -> str:
-        found = False
+    def find_nearest_path_str(self, teams, path_string, from_date=None) -> str:
         newTeams = []
         if from_date:
             self.set_from_date(from_date)
         for tm in teams:
             splits = tm.split(" -> ")
             cur_match: Match = self.find_match(splits[-1], self.from_date)
-            if cur_match and cur_match.away == self.team or cur_match.home == self.team:
-                found = True
-                path_string = f"{tm} -> {cur_match}"
-                break
-            newTeams.append(f"{tm} -> {cur_match} -> {cur_match.away}")
-            newTeams.append(f"{tm} -> {cur_match} -> {cur_match.home}")
+            if cur_match:
+                if cur_match.away == self.team or cur_match.home == self.team:
+                    return f"{tm} -> {cur_match}"
+                newTeams.append(f"{tm} -> {cur_match} -> {cur_match.away}")
+                newTeams.append(f"{tm} -> {cur_match} -> {cur_match.home}")
 
-        if found:
-            return path_string
-        else:
-            path_string = self.find_nearest_path(newTeams, path_string, cur_match.date)
+        path_string = self.find_nearest_path_str(
+            newTeams, path_string, cur_match.serial_date
+        )
         return path_string
+
+    def find_nearest_path_games(self):
+        """Find the shortest path from the current belt holder's next game until
+        self.team has a chance to play for the belt. May involve the belt changing
+        hands in between.
+
+        Requires
+        """
+        first_match: Match = self.find_match(self.belt_holder, self.from_date)
+        matches = [[first_match]]
+        depth = 0
+        while matches[depth]:
+            cur_matches = matches[depth]
+            next_matches = []
+            for m in cur_matches:
+                if m.away == self.team or m.home == self.team:
+                    return traverse_matches_backwards(match=m)
+                else:
+                    next_match_home = self.find_match(m.home, m.date_obj)
+                    if next_match_home:
+                        # else no more matches for home team
+                        next_match_home.away_last = m
+                        next_matches.append(next_match_home)
+
+                    next_match_away = self.find_match(m.away, m.date_obj)
+                    if next_match_away:
+                        # else no more matches for away team
+                        next_match_away.home_last = m
+                        next_matches.append(next_match_away)
+            depth += 1
+            if len(next_matches) > 0:
+                matches.append(next_matches)
+
+        # didn't find a path (raise an Exception or something?)
+        return None
+
+    def get_matches_for_team(self, team):
+        team_matches: list[Match] = [
+            match for match in self.matches if match.away == team or match.home == team
+        ]
+        team_matches.sort(key=lambda m: m.serial_date)
+        for i, m in enumerate(team_matches):
+            last_match = team_matches[i - 1]
+            if m.away == team and i > 0:
+                m.away_last = last_match
+            elif m.home == team and i > 0:
+                m.home_last = last_match
+
+        return team_matches
 
     @classmethod
     def find_current_belt_holder(

--- a/title_belt_nhl/tests/test_files/mock_league_schedule.json
+++ b/title_belt_nhl/tests/test_files/mock_league_schedule.json
@@ -18,7 +18,7 @@
     }
   },
   {
-    "id": 2023010045,
+    "id": 2023010046,
     "season": 20232024,
     "gameType": 2,
     "gameDate": "2023-09-28",
@@ -36,7 +36,7 @@
     }
   },
   {
-    "id": 2023010045,
+    "id": 2023010047,
     "season": 20232024,
     "gameType": 2,
     "gameDate": "2023-09-29",
@@ -53,9 +53,8 @@
       "score": 1
     }
   },
-
   {
-    "id": 2023010045,
+    "id": 2023010048,
     "season": 20232024,
     "gameType": 2,
     "gameDate": "2023-09-30",
@@ -68,6 +67,38 @@
     "homeTeam": {
       "id": 16,
       "abbrev": "CHI"
+    }
+  },
+  {
+    "id": 2023010049,
+    "season": 20232024,
+    "gameType": 2,
+    "gameDate": "2023-09-30",
+    "gameState": "FUT",
+    "gameScheduleState": "OK",
+    "awayTeam": {
+      "id": 19,
+      "abbrev": "PIT"
+    },
+    "homeTeam": {
+      "id": 16,
+      "abbrev": "DAL"
+    }
+  },
+  {
+    "id": 2023010050,
+    "season": 20232024,
+    "gameType": 2,
+    "gameDate": "2023-10-01",
+    "gameState": "FUT",
+    "gameScheduleState": "OK",
+    "awayTeam": {
+      "id": 19,
+      "abbrev": "DAL"
+    },
+    "homeTeam": {
+      "id": 16,
+      "abbrev": "VAN"
     }
   }
 ]

--- a/title_belt_nhl/tests/test_files/mock_league_schedule_big.json
+++ b/title_belt_nhl/tests/test_files/mock_league_schedule_big.json
@@ -1,0 +1,1334 @@
+[
+    {
+        "id": 2024020001,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-04",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 1,
+            "abbrev": "NJD",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 7,
+            "abbrev": "BUF",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020002,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-05",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 7,
+            "abbrev": "BUF",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 1,
+            "abbrev": "NJD",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020005,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-08",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 16,
+            "abbrev": "CHI",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 59,
+            "abbrev": "UTA",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020004,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-08",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 6,
+            "abbrev": "BOS",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 13,
+            "abbrev": "FLA",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020003,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-08",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 19,
+            "abbrev": "STL",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 55,
+            "abbrev": "SEA",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020009,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-09",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 20,
+            "abbrev": "CGY",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 23,
+            "abbrev": "VAN",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020008,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-09",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 52,
+            "abbrev": "WPG",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 22,
+            "abbrev": "EDM",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020010,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-09",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 21,
+            "abbrev": "COL",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 54,
+            "abbrev": "VGK",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020007,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-09",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 3,
+            "abbrev": "NYR",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 5,
+            "abbrev": "PIT",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020006,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-09",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 10,
+            "abbrev": "TOR",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 8,
+            "abbrev": "MTL",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020015,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-10",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 10,
+            "abbrev": "TOR",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 1,
+            "abbrev": "NJD",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020016,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-10",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 59,
+            "abbrev": "UTA",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 2,
+            "abbrev": "NYI",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020012,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-10",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 26,
+            "abbrev": "LAK",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 7,
+            "abbrev": "BUF",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020011,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-10",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 8,
+            "abbrev": "MTL",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 6,
+            "abbrev": "BOS",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020018,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-10",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 29,
+            "abbrev": "CBJ",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 30,
+            "abbrev": "MIN",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020019,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-10",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 19,
+            "abbrev": "STL",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 28,
+            "abbrev": "SJS",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020014,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-10",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 5,
+            "abbrev": "PIT",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 17,
+            "abbrev": "DET",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020013,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-10",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 13,
+            "abbrev": "FLA",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 9,
+            "abbrev": "OTT",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020017,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-10",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 25,
+            "abbrev": "DAL",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 18,
+            "abbrev": "NSH",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020020,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-11",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 14,
+            "abbrev": "TBL",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 12,
+            "abbrev": "CAR",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020021,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-11",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 16,
+            "abbrev": "CHI",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 52,
+            "abbrev": "WPG",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020022,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-11",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 4,
+            "abbrev": "PHI",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 23,
+            "abbrev": "VAN",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020023,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-11",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 19,
+            "abbrev": "STL",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 54,
+            "abbrev": "VGK",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020029,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-12",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 12,
+            "abbrev": "CAR",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 14,
+            "abbrev": "TBL",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020036,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-12",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 16,
+            "abbrev": "CHI",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 22,
+            "abbrev": "EDM",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020031,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-12",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 1,
+            "abbrev": "NJD",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 15,
+            "abbrev": "WSH",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020032,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-12",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 2,
+            "abbrev": "NYI",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 25,
+            "abbrev": "DAL",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020035,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-12",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 4,
+            "abbrev": "PHI",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 20,
+            "abbrev": "CGY",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020025,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-12",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 13,
+            "abbrev": "FLA",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 7,
+            "abbrev": "BUF",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020034,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-12",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 29,
+            "abbrev": "CBJ",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 21,
+            "abbrev": "COL",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020024,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-12",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 26,
+            "abbrev": "LAK",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 6,
+            "abbrev": "BOS",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020030,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-12",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 59,
+            "abbrev": "UTA",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 3,
+            "abbrev": "NYR",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020033,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-12",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 55,
+            "abbrev": "SEA",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 30,
+            "abbrev": "MIN",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020027,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-12",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 9,
+            "abbrev": "OTT",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 8,
+            "abbrev": "MTL",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020028,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-12",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 18,
+            "abbrev": "NSH",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 17,
+            "abbrev": "DET",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020037,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-12",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 24,
+            "abbrev": "ANA",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 28,
+            "abbrev": "SJS",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020026,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-12",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 5,
+            "abbrev": "PIT",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 10,
+            "abbrev": "TOR",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020040,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-13",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 20,
+            "abbrev": "CGY",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 22,
+            "abbrev": "EDM",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020038,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-13",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 30,
+            "abbrev": "MIN",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 52,
+            "abbrev": "WPG",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020039,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-13",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 55,
+            "abbrev": "SEA",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 25,
+            "abbrev": "DAL",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020041,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-13",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 24,
+            "abbrev": "ANA",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 54,
+            "abbrev": "VGK",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020044,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-14",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 59,
+            "abbrev": "UTA",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 1,
+            "abbrev": "NJD",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020047,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-14",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 2,
+            "abbrev": "NYI",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 21,
+            "abbrev": "COL",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020042,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-14",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 13,
+            "abbrev": "FLA",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 6,
+            "abbrev": "BOS",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020045,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-14",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 17,
+            "abbrev": "DET",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 3,
+            "abbrev": "NYR",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020043,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-14",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 26,
+            "abbrev": "LAK",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 9,
+            "abbrev": "OTT",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020046,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-14",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 5,
+            "abbrev": "PIT",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 8,
+            "abbrev": "MTL",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020050,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-15",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 1,
+            "abbrev": "NJD",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 12,
+            "abbrev": "CAR",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020055,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-15",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 16,
+            "abbrev": "CHI",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 20,
+            "abbrev": "CGY",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020048,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-15",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 23,
+            "abbrev": "VAN",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 14,
+            "abbrev": "TBL",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020056,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-15",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 4,
+            "abbrev": "PHI",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 22,
+            "abbrev": "EDM",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020052,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-15",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 30,
+            "abbrev": "MIN",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 19,
+            "abbrev": "STL",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020053,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-15",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 55,
+            "abbrev": "SEA",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 18,
+            "abbrev": "NSH",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020051,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-15",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 13,
+            "abbrev": "FLA",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 29,
+            "abbrev": "CBJ",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020054,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-15",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 28,
+            "abbrev": "SJS",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 25,
+            "abbrev": "DAL",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020049,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-15",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 54,
+            "abbrev": "VGK",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 15,
+            "abbrev": "WSH",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020057,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-16",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 7,
+            "abbrev": "BUF",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 5,
+            "abbrev": "PIT",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020059,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-16",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 6,
+            "abbrev": "BOS",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 21,
+            "abbrev": "COL",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020058,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-16",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 26,
+            "abbrev": "LAK",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 10,
+            "abbrev": "TOR",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020060,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-16",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 59,
+            "abbrev": "UTA",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 24,
+            "abbrev": "ANA",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020070,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-17",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 28,
+            "abbrev": "SJS",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 16,
+            "abbrev": "CHI",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020062,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-17",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 1,
+            "abbrev": "NJD",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 9,
+            "abbrev": "OTT",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020068,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-17",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 2,
+            "abbrev": "NYI",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 19,
+            "abbrev": "STL",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020067,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-17",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 7,
+            "abbrev": "BUF",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 29,
+            "abbrev": "CBJ",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020064,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-17",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 54,
+            "abbrev": "VGK",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 14,
+            "abbrev": "TBL",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020065,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-17",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 23,
+            "abbrev": "VAN",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 13,
+            "abbrev": "FLA",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020063,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-17",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 3,
+            "abbrev": "NYR",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 17,
+            "abbrev": "DET",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020061,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-17",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 26,
+            "abbrev": "LAK",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 8,
+            "abbrev": "MTL",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020071,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-17",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 4,
+            "abbrev": "PHI",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 55,
+            "abbrev": "SEA",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020066,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-17",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 25,
+            "abbrev": "DAL",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 15,
+            "abbrev": "WSH",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020069,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-17",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 22,
+            "abbrev": "EDM",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 18,
+            "abbrev": "NSH",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020072,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-18",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 12,
+            "abbrev": "CAR",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 5,
+            "abbrev": "PIT",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020073,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-18",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 28,
+            "abbrev": "SJS",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 52,
+            "abbrev": "WPG",
+            "score": null
+        }
+    },
+    {
+        "id": 2024020074,
+        "season": 20242025,
+        "gameType": 2,
+        "gameDate": "2024-10-18",
+        "gameState": "FUT",
+        "gameScheduleState": "OK",
+        "awayTeam": {
+            "id": 24,
+            "abbrev": "ANA",
+            "score": null
+        },
+        "homeTeam": {
+            "id": 21,
+            "abbrev": "COL",
+            "score": null
+        }
+    }
+]

--- a/title_belt_nhl/tests/test_schedule.py
+++ b/title_belt_nhl/tests/test_schedule.py
@@ -1,17 +1,80 @@
 import json
+from datetime import date
+from unittest.mock import Mock
 
-from title_belt_nhl.main import Schedule
+import pytest
+
 from title_belt_nhl.models.nhl_team_schedule_response import Game
+from title_belt_nhl.schedule import Match, Schedule
+
+MOCK_DATA_PATH = "./title_belt_nhl/tests/test_files/mock_league_schedule.json"
 
 
-def test_current_title_belt_holder():
-    mock_data_path = "./title_belt_nhl/tests/test_files/mock_league_schedule.json"
-
+@pytest.fixture()
+def league_schedule():
     # Open the file and load the JSON data
-    with open(mock_data_path, "r") as file:
+    with open(MOCK_DATA_PATH, "r") as file:
         data = json.load(file)
-        leagueSchedule: list[Game] = [Game.from_dict(game) for game in data]
+        return [Game.from_dict(game) for game in data]
 
-    leagueSchedule.sort(key=lambda x: x.gameDate)
-    cur_belt_holder = Schedule.find_current_belt_holder(leagueSchedule, "CHI")
-    assert cur_belt_holder == "PIT"
+
+class TestSchedule:
+    def test_current_title_belt_holder(self, league_schedule):
+        league_schedule.sort(key=lambda x: x.gameDate)
+        cur_belt_holder = Schedule.find_current_belt_holder(league_schedule, "CHI")
+        assert cur_belt_holder == "PIT"
+
+    def test_find_match(self, monkeypatch, league_schedule):
+        m = Mock()
+        m.return_value = league_schedule
+        monkeypatch.setattr("title_belt_nhl.schedule.getFullSchedule", m)
+        monkeypatch.setattr("title_belt_nhl.schedule.INITIAL_BELT_HOLDER", "CHI")
+
+        schedule = Schedule("VAN", from_date=date(2023, 9, 29))
+        assert schedule.belt_holder == "PIT"
+        assert len(schedule.matches) == 6
+
+        match = schedule.find_match(schedule.belt_holder, date(2023, 9, 29))
+        expected = Match("DAL", "PIT", date_obj=date(2023, 9, 30))
+        assert str(match) == str(expected)
+        assert match.date_obj == expected.date_obj
+
+    def test_find_nearest_path_str(self, monkeypatch, league_schedule):
+        m = Mock()
+        m.return_value = league_schedule
+        monkeypatch.setattr("title_belt_nhl.schedule.getFullSchedule", m)
+
+        monkeypatch.setattr("title_belt_nhl.schedule.INITIAL_BELT_HOLDER", "CHI")
+
+        schedule = Schedule("VAN", from_date=date(2023, 9, 29))
+        assert schedule.belt_holder == "PIT"
+        assert len(schedule.matches) == 6
+
+        path = schedule.find_nearest_path_str(
+            [schedule.belt_holder], schedule.belt_holder
+        )
+        assert len(path.split("vs")) - 1 == 2
+
+        expected = "PIT -> [DAL vs PIT] -> DAL -> [VAN vs DAL]"
+        assert path == expected
+
+    def test_find_nearest_path_games(self, monkeypatch, league_schedule):
+        m = Mock()
+        m.return_value = league_schedule
+        monkeypatch.setattr("title_belt_nhl.schedule.getFullSchedule", m)
+
+        monkeypatch.setattr("title_belt_nhl.schedule.INITIAL_BELT_HOLDER", "CHI")
+
+        schedule = Schedule("VAN", from_date=date(2023, 9, 29))
+        assert schedule.belt_holder == "PIT"
+        assert len(schedule.matches) == 6
+
+        path_matches = schedule.find_nearest_path_games()
+        assert len(path_matches) == 2
+
+        m1 = Match("DAL", "PIT", date_obj=date(2023, 9, 30))
+        m2 = Match("VAN", "DAL", date_obj=date(2023, 10, 1))
+        expected = [m1, m2]
+        for i, m in enumerate(expected):
+            assert str(path_matches[i]) == str(m)
+            assert path_matches[i].date_obj == m.date_obj

--- a/title_belt_nhl/tests/test_schedule.py
+++ b/title_belt_nhl/tests/test_schedule.py
@@ -8,12 +8,21 @@ from title_belt_nhl.models.nhl_team_schedule_response import Game
 from title_belt_nhl.schedule import Match, Schedule
 
 MOCK_DATA_PATH = "./title_belt_nhl/tests/test_files/mock_league_schedule.json"
+MOCK_DATA_PATH_BIG = "./title_belt_nhl/tests/test_files/mock_league_schedule_big.json"
 
 
 @pytest.fixture()
 def league_schedule():
     # Open the file and load the JSON data
     with open(MOCK_DATA_PATH, "r") as file:
+        data = json.load(file)
+        return [Game.from_dict(game) for game in data]
+
+
+@pytest.fixture()
+def league_schedule_big():
+    # Open the file and load the JSON data
+    with open(MOCK_DATA_PATH_BIG, "r") as file:
         data = json.load(file)
         return [Game.from_dict(game) for game in data]
 
@@ -75,6 +84,53 @@ class TestSchedule:
         m1 = Match("DAL", "PIT", date_obj=date(2023, 9, 30))
         m2 = Match("VAN", "DAL", date_obj=date(2023, 10, 1))
         expected = [m1, m2]
+        for i, m in enumerate(expected):
+            assert str(path_matches[i]) == str(m)
+            assert path_matches[i].date_obj == m.date_obj
+
+    def test_find_nearest_path_str_big(self, monkeypatch, league_schedule_big):
+        m = Mock()
+        m.return_value = league_schedule_big
+        monkeypatch.setattr("title_belt_nhl.schedule.getFullSchedule", m)
+
+        monkeypatch.setattr("title_belt_nhl.schedule.INITIAL_BELT_HOLDER", "FLA")
+
+        schedule = Schedule("CAR", from_date=date(2024, 10, 3))
+        assert schedule.belt_holder == "FLA"
+        assert len(schedule.matches) == 74
+
+        path = schedule.find_nearest_path_str(
+            [schedule.belt_holder], schedule.belt_holder
+        )
+        assert len(path.split("vs")) - 1 == 6
+
+        # this is what the fn returns now, but it's not the shortest path
+        # TODO: fix the fn so it returns the (a) shortest path
+        expected_wrong = "FLA -> [FLA vs BOS] -> BOS -> [BOS vs MTL] -> MTL -> [MTL vs OTT] -> MTL -> [MTL vs PIT] -> PIT -> [PIT vs BUF] -> PIT -> [PIT vs CAR]"  # noqa: E501
+        assert path == expected_wrong
+
+    def test_find_nearest_path_games_big(self, monkeypatch, league_schedule_big):
+        m = Mock()
+        m.return_value = league_schedule_big
+        monkeypatch.setattr("title_belt_nhl.schedule.getFullSchedule", m)
+
+        monkeypatch.setattr("title_belt_nhl.schedule.INITIAL_BELT_HOLDER", "FLA")
+
+        schedule = Schedule("CAR", from_date=date(2024, 10, 3))
+        assert schedule.belt_holder == "FLA"
+        assert len(schedule.matches) == 74
+
+        path_matches = schedule.find_nearest_path_games()
+        for i, m in enumerate(path_matches):
+            print(f"{path_matches[i].date_obj} {path_matches[i]}")
+        assert len(path_matches) == 5
+
+        m1 = Match("FLA", "BOS", date_obj=date(2024, 10, 8))
+        m2 = Match("OTT", "FLA", date_obj=date(2024, 10, 10))
+        m3 = Match("BUF", "FLA", date_obj=date(2024, 10, 12))
+        m4 = Match("PIT", "BUF", date_obj=date(2024, 10, 16))
+        m5 = Match("PIT", "CAR", date_obj=date(2024, 10, 18))
+        expected = [m1, m2, m3, m4, m5]
         for i, m in enumerate(expected):
             assert str(path_matches[i]) == str(m)
             assert path_matches[i].date_obj == m.date_obj


### PR DESCRIPTION
I changed a lot of var names, so I bumped a whole minor version instead of a patch.

- refactored a ton of stuff as I saw things, like `find_nearest_path` (which is now called `find_nearest_path_str`)
- `find_nearest_path_games` finds the nearest path but does it iteratively, and more importantly returns the list of Matches
- added some more schedule tests, particularly for the nearest path functions
  - the tests check existing functionality, not whether they are correct or most correct paths