### PR TITLE
feat: get full schedule on nearest path; track shortest path in schedule

### DIFF
--- a/title_belt_nhl/main.py
+++ b/title_belt_nhl/main.py
@@ -41,8 +41,11 @@ def path(ctx):
     else:
         path_matches = schedule.find_nearest_path_games()
         click.echo(f"{len(path_matches)} GAMES UNTIL `{team}` HAS A SHOT AT THE BELT")
-        for match in path_matches:
-            click.echo(f"\t{match.date_obj} | {match.belt_holder} -> {match}")
+        for depth, match_list in enumerate(path_matches):
+            click.echo(f"{depth}: {len(match_list)}")
+            for match in match_list:
+                on_shortest_path = "*" if match.on_shortest_path else ""
+                click.echo(f"\t{match.date_obj} | {match.belt_holder} -> {match} {on_shortest_path}")
 
 
 @cli.command()

--- a/title_belt_nhl/main.py
+++ b/title_belt_nhl/main.py
@@ -44,8 +44,10 @@ def path(ctx):
         for depth, match_list in enumerate(path_matches):
             click.echo(f"{depth}: {len(match_list)}")
             for match in match_list:
-                on_shortest_path = "*" if match.on_shortest_path else ""
-                click.echo(f"\t{match.date_obj} | {match.belt_holder} -> {match} {on_shortest_path}")
+                on_path = "*" if match.on_shortest_path else ""
+                click.echo(
+                    f"\t{match.date_obj} | {match.belt_holder} -> {match} {on_path}"
+                )
 
 
 @cli.command()

--- a/title_belt_nhl/schedule.py
+++ b/title_belt_nhl/schedule.py
@@ -200,7 +200,7 @@ class Schedule:
         scenario_copy.append(next_match)
         return scenario_copy
 
-    def find_nearest_path_games(self):
+    def find_nearest_path_games(self) -> list[list[Match]]:
         """Find the shortest path from the current belt holder's next game until
         self.team has a chance to play for the belt. May involve the belt changing
         hands in between.

--- a/title_belt_nhl/schedule.py
+++ b/title_belt_nhl/schedule.py
@@ -68,8 +68,12 @@ def traverse_matches_backwards(
         if not last_match:
             break
         last_match.on_shortest_path = True
-        last_match.home_next = cur_match if last_match.home in [cur_match.home, cur_match.away] else None
-        last_match.away_next = cur_match if last_match.away in [cur_match.home, cur_match.away] else None
+        last_match.home_next = (
+            cur_match if last_match.home in [cur_match.home, cur_match.away] else None
+        )
+        last_match.away_next = (
+            cur_match if last_match.away in [cur_match.home, cur_match.away] else None
+        )
         cur_match = last_match
 
     return path_matches

--- a/title_belt_nhl/schedule.py
+++ b/title_belt_nhl/schedule.py
@@ -18,8 +18,11 @@ class Match:
     serial_date: int
     date_obj: date
     belt_holder: str = None
-    home_last: str = None
-    away_last: str = None
+    home_last: "Match" = None
+    away_last: "Match" = None
+    home_next: "Match" = None
+    away_next: "Match" = None
+    on_shortest_path: bool = False
 
     def __init__(self, home, away, serial_date=None, date_obj=None, belt_holder=None):
         self.home = home
@@ -64,6 +67,9 @@ def traverse_matches_backwards(
 
         if not last_match:
             break
+        last_match.on_shortest_path = True
+        last_match.home_next = cur_match if last_match.home in [cur_match.home, cur_match.away] else None
+        last_match.away_next = cur_match if last_match.away in [cur_match.home, cur_match.away] else None
         cur_match = last_match
 
     return path_matches
@@ -200,12 +206,15 @@ class Schedule:
         first_match: Match = self.find_match(self.belt_holder, self.from_date)
         matches = [[first_match]]
         depth = 0
-        while matches[depth]:
+        found = False
+        while matches[depth] and not found:
             cur_matches = matches[depth]
             next_matches = []
             for m in cur_matches:
                 if m.away == self.team or m.home == self.team:
-                    return traverse_matches_backwards(match=m)
+                    traverse_matches_backwards(match=m)
+                    m.on_shortest_path = True
+                    found = True
                 else:
                     next_match_home = self.find_match(m.home, m.date_obj)
                     if next_match_home:
@@ -218,10 +227,13 @@ class Schedule:
                         # else no more matches for away team
                         next_match_away.home_last = m
                         next_matches.append(next_match_away)
-            depth += 1
-            if len(next_matches) > 0:
-                matches.append(next_matches)
+            if not found:
+                depth += 1
+                if len(next_matches) > 0:
+                    matches.append(next_matches)
 
+        if found:
+            return matches
         # didn't find a path (raise an Exception or something?)
         return None
 

--- a/title_belt_nhl/tests/test_schedule.py
+++ b/title_belt_nhl/tests/test_schedule.py
@@ -88,9 +88,14 @@ class TestSchedule:
         m1 = Match("DAL", "PIT", date_obj=date(2023, 9, 30))
         m2 = Match("VAN", "DAL", date_obj=date(2023, 10, 1))
         expected = [m1, m2]
-        for i, m in enumerate(expected):
-            assert str(path_matches[i]) == str(m)
-            assert path_matches[i].date_obj == m.date_obj
+        found = [False, False]
+        for d, match_list in enumerate(path_matches):
+            for m in match_list:
+                if str(expected[d]) == str(m) and expected[d].date_obj == m.date_obj:
+                    found[d] = True
+                    assert m.on_shortest_path
+
+        assert all(found)
 
     def test_find_nearest_path_str_big(self, monkeypatch, league_schedule_big):
         m = Mock()
@@ -129,8 +134,6 @@ class TestSchedule:
         assert len(schedule.matches) == 169
 
         path_matches = schedule.find_nearest_path_games()
-        for i, m in enumerate(path_matches):
-            print(f"{path_matches[i].date_obj} {path_matches[i]}")
         assert len(path_matches) == 5
 
         m1 = Match("FLA", "BOS", date_obj=date(2024, 10, 8))
@@ -139,9 +142,14 @@ class TestSchedule:
         m4 = Match("PIT", "BUF", date_obj=date(2024, 10, 16))
         m5 = Match("PIT", "CAR", date_obj=date(2024, 10, 18))
         expected = [m1, m2, m3, m4, m5]
-        for i, m in enumerate(expected):
-            assert str(path_matches[i]) == str(m)
-            assert path_matches[i].date_obj == m.date_obj
+        found = [False, False, False, False, False]
+        for d, match_list in enumerate(path_matches):
+            for m in match_list:
+                if str(expected[d]) == str(m) and expected[d].date_obj == m.date_obj:
+                    found[d] = True
+                    assert m.on_shortest_path
+
+        assert all(found)
 
     def test_find_nearest_path_v2(self, monkeypatch, league_schedule_big):
         m = Mock()


### PR DESCRIPTION
```
poetry run title_belt_nhl --team MIN path
```
prints the depth, how many matches at that depth, and each game at that depth (`*` denotes match is on the shortest path) -->
![image](https://github.com/user-attachments/assets/18b7bdcd-32fc-4a50-9d11-4daef65be162)
