### PR TITLE
feat: only find one 'shortest' path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "title-belt-nhl"
-version = "0.3.2"
+version = "0.3.3"
 description = "CLI tool to compute NHL Title Belt info."
 authors = ["kawa2287", "elffaW"]
 readme = "README.md"


### PR DESCRIPTION
Previous version was finding multiple paths, which was kind of neat but not intended. I left myself some comments on how to change it back if we find that desirable, but this version just finds the first viable path at a given depth.

Would be neat to optimize this for earliest date in the case of multiple paths, but I didn't see any obvious way to do this so I'll make a ticket instead.