### PR TITLE
fix: scores are now set properly for belt path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "title-belt-nhl"
-version = "0.3.4"
+version = "0.3.5"
 description = "CLI tool to compute NHL Title Belt info."
 authors = ["kawa2287", "elffaW"]
 readme = "README.md"

--- a/title_belt_nhl/main.py
+++ b/title_belt_nhl/main.py
@@ -93,4 +93,7 @@ def belt_path(ctx):
         click.echo("COULD NOT COMPUTE BELT PATH SO FAR")
     else:
         for match in path_matches:
-            click.echo(f"\t{match.date_obj} | {match.belt_holder} -> {match}")
+            click.echo(
+                f"\t{match.date_obj}\t{match.belt_holder} -> {match}"
+                + f"\t({match.home_score} - {match.away_score})"
+            )

--- a/title_belt_nhl/schedule.py
+++ b/title_belt_nhl/schedule.py
@@ -63,13 +63,22 @@ class Match:
     def from_game(cls, game: Game):
         game_date_obj = datetime.strptime(game.gameDate, "%Y-%m-%d").date()
 
+        home_score = None
+        away_score = None
+
+        try:
+            home_score = game.homeTeam["score"]
+            away_score = game.awayTeam["score"]
+        except KeyError:
+            pass
+
         return Match(
             game.homeTeam["abbrev"],
             game.awayTeam["abbrev"],
             serial_date=ExcelDate(date_obj=game_date_obj).serial_date,
             date_obj=game_date_obj,
-            home_score=getattr(game.homeTeam, "score", None),
-            away_score=getattr(game.awayTeam, "score", None),
+            home_score=home_score,
+            away_score=away_score,
         )
 
 
@@ -317,7 +326,7 @@ class Schedule:
         league_schedule: list[Game],
         schedule: "Schedule" = None,
         start_belt_holder: str = INITIAL_BELT_HOLDER,
-    ) -> str:
+    ) -> list[Match]:
         """
         Given an array of `Game` and the Abbreviation of the season start belt holder,
         Return the path that the belt has taken so far, based off of game results.


### PR DESCRIPTION
not sure what was going on here, but I couldn't figure out how to determine if the `team.score` property existed without this silly try/except